### PR TITLE
fix: update pattern-check.sh path for Projects reorg

### DIFF
--- a/scripts/pattern-check.sh
+++ b/scripts/pattern-check.sh
@@ -567,7 +567,7 @@ record_metrics() {
 
     # Also check claude-setup location
     if [[ ! -f "$metrics_script" ]]; then
-        metrics_script="${HOME}/Projects/claude-setup/scripts/pattern-metrics.sh"
+        metrics_script="${HOME}/Projects/internal/claude-setup/scripts/pattern-metrics.sh"
     fi
 
     if [[ ! -f "$metrics_script" ]] || [[ ! -x "$metrics_script" ]]; then


### PR DESCRIPTION
Update stale ~/Projects/claude-setup to ~/Projects/internal/claude-setup in pattern-check.sh metrics fallback path.