### PR TITLE
chore: reduce scheduled workflow frequency

### DIFF
--- a/.github/workflows/daily-deploy-check.yml
+++ b/.github/workflows/daily-deploy-check.yml
@@ -16,8 +16,8 @@ name: Daily Deploy Check
 
 on:
   schedule:
-    # Every day at 6am UTC
-    - cron: '0 6 * * *'
+    # Every Monday at 6am UTC
+    - cron: '0 6 * * 1'
   workflow_dispatch: # Manual trigger
 
 env:

--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -13,8 +13,8 @@ name: Weekly Audit
 
 on:
   schedule:
-    # Every Sunday at 2am UTC
-    - cron: '0 2 * * 0'
+    # Monthly on 1st at 2am UTC
+    - cron: '0 2 1 * *'
   workflow_dispatch: # Manual trigger
 
 env:


### PR DESCRIPTION
## Summary
- `weekly-audit.yml`: weekly → monthly (saves ~3 runs/month)
- `daily-deploy-check.yml`: daily → weekly/Monday (saves ~24 runs/month)

## Before / After
| Workflow | Before | After | Savings |
|----------|--------|-------|---------|
| weekly-audit | 4x/month | 1x/month | -3 runs |
| daily-deploy-check | 30x/month | 4x/month | -26 runs |

## Notes
- Daily deploy checks are excessive for a side project. Weekly Monday is sufficient.
- `quality.yml` security was already monthly (`0 0 1 * *`) — no change needed there

🤖 Generated with [Claude Code](https://claude.com/claude-code)