### PR TITLE
fix: remove .html from ESLint patterns (no HTML parser installed)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -32,4 +32,3 @@ jobs:
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -101,7 +101,6 @@ jobs:
         with:
           bun-version: '1.0.0'
 
-
       - name: Display Detection Report
         run: |
           echo "📊 Project Detection Results (Minimal Mode)"
@@ -312,7 +311,6 @@ jobs:
             echo "::error::Test suite exceeded 5-minute performance budget!"
             exit 1
           }
-
 
   # Step 4: Documentation - run for production-ready projects
   documentation:

--- a/eslint-security.config.js
+++ b/eslint-security.config.js
@@ -6,7 +6,7 @@ const security = require('eslint-plugin-security')
 module.exports = [
   {
     plugins: {
-      security
+      security,
     },
     rules: {
       // Critical security rules (errors)
@@ -25,7 +25,7 @@ module.exports = [
       // Warning-level security rules
       'security/detect-bidi-characters': 'warn',
       'security/detect-non-literal-fs-filename': 'warn',
-      'security/detect-non-literal-require': 'warn'
-    }
-  }
+      'security/detect-non-literal-require': 'warn',
+    },
+  },
 ]

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -63,7 +63,7 @@ const securityRules = security
   : {}
 
 configs.push({
-  files: ['**/*.{js,jsx,mjs,cjs,html}'],
+  files: ['**/*.{js,jsx,mjs,cjs}'],
   languageOptions: {
     ecmaVersion: 2022,
     sourceType: 'module',

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "format:check": "prettier --check .",
     "security:audit": "npm audit --audit-level high",
     "security:secrets": "node -e \"const fs=require('fs');const content=fs.readFileSync('package.json','utf8');if(/[\\\"\\'][a-zA-Z0-9+/]{20,}[\\\"\\']/.test(content)){console.error('❌ Potential hardcoded secrets in package.json');process.exit(1)}else{console.log('✅ No secrets detected in package.json')}\"",
-    "lint": "eslint . --ext .js,.jsx,.mjs,.cjs,.html && stylelint \"**/*.{css,scss,sass,less,pcss}\" --allow-empty-input",
+    "lint": "eslint . --ext .js,.jsx,.mjs,.cjs && stylelint \"**/*.{css,scss,sass,less,pcss}\" --allow-empty-input",
     "type-check": "tsc --noEmit",
-    "lint:fix": "eslint . --ext .js,.jsx,.mjs,.cjs,.html --fix && stylelint \"**/*.{css,scss,sass,less,pcss}\" --fix --allow-empty-input",
+    "lint:fix": "eslint . --ext .js,.jsx,.mjs,.cjs --fix && stylelint \"**/*.{css,scss,sass,less,pcss}\" --fix --allow-empty-input",
     "prepare": "[ \"$CI\" = \"true\" ] && echo 'Skipping Husky in CI' || husky",
     "security:config": "npx create-quality-automation@latest --security-config",
     "lighthouse:ci": "lhci autorun",
@@ -83,7 +83,7 @@
     "package.json": [
       "prettier --write"
     ],
-    "**/*.{js,jsx,mjs,cjs,html}": [
+    "**/*.{js,jsx,mjs,cjs}": [
       "eslint --fix",
       "prettier --write"
     ],
@@ -94,7 +94,7 @@
       "stylelint --fix",
       "prettier --write"
     ],
-    "**/*.{js,jsx,ts,tsx,mjs,cjs,html}": [
+    "**/*.{js,jsx,ts,tsx,mjs,cjs}": [
       "eslint --fix",
       "prettier --write"
     ],

--- a/tests/accessibility.test.js
+++ b/tests/accessibility.test.js
@@ -24,7 +24,6 @@ describe('Accessibility Tests', () => {
     // const puppeteer = require('puppeteer')
     // browser = await puppeteer.launch()
     // const page = await browser.newPage()
-
     // For now, this is a placeholder that passes
     // Replace with actual implementation based on your framework
   })

--- a/tests/tsconfig.json
+++ b/tests/tsconfig.json
@@ -3,21 +3,8 @@
   "compilerOptions": {
     "rootDir": "..",
     "noEmit": true,
-    "types": [
-      "vitest/globals",
-      "node",
-      "@types/jest"
-    ]
+    "types": ["vitest/globals", "node", "@types/jest"]
   },
-  "include": [
-    "../src/**/*",
-    "../tests/**/*",
-    "../*.ts",
-    "../*.js"
-  ],
-  "exclude": [
-    "../node_modules",
-    "../dist",
-    "../build"
-  ]
+  "include": ["../src/**/*", "../tests/**/*", "../*.ts", "../*.js"],
+  "exclude": ["../node_modules", "../dist", "../build"]
 }


### PR DESCRIPTION
## Summary
- ESLint v9 flat config was attempting to parse `web/index.html` as JavaScript, failing with `Parsing error: Unexpected token <`
- Root cause: `eslint.config.cjs` files glob included `.html` but no `eslint-plugin-html` is installed
- Removed `.html` from file patterns in `eslint.config.cjs`, `lint`/`lint:fix` scripts, and `lint-staged` config
- Applied prettier formatting to 5 files flagged by `format:check`

## Test plan
- [x] `npm run lint` passes
- [x] `npm run format:check` passes
- [x] `npm run test:ci` passes (12 unit tests)
- [x] `npm run test:integration` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)